### PR TITLE
Refactor: Derive workspace_root_path dynamically

### DIFF
--- a/army-man-small-tweak/config.yml
+++ b/army-man-small-tweak/config.yml
@@ -1,7 +1,6 @@
 # Application configuration for PoC7 Orchestrator
 # TODO: Remove workspace root path - should bea ble to derive this from python file paths like we do in the Secretary code
 # workspace_root_path: "C:\\GithubRepos\\Sleepy-AI-Army\\army-man-small-tweak" 
-workspace_root_path: "C:\\GithubRepos\\Sleepy-Dev-Team\\army-man-small-tweak" 
 goal_root_path: "C:\\GithubRepos\\Project-Elder\\projects\\isometric_2d_prototype\\ai-goals\\SmallTweak_001_Document_Function_01"
 goal_git_path: "C:\\GithubRepos\\Project-Elder"
 

--- a/army-man-small-tweak/src/config.py
+++ b/army-man-small-tweak/src/config.py
@@ -1,5 +1,6 @@
 """Pydantic model for application configuration."""
 import logging
+import os
 from pydantic import BaseModel, ValidationError
 from typing import List, Optional # List will be replaced by list if used
 from omegaconf import OmegaConf, MissingMandatoryValue
@@ -7,7 +8,6 @@ from omegaconf import OmegaConf, MissingMandatoryValue
 logger = logging.getLogger(__name__)
 
 class AppConfig(BaseModel):
-    workspace_root_path: str
     goal_root_path: str
     goal_git_path: str # Path to the root of the Git repo that contains the goal_root_path
     task_description_filename: str
@@ -24,6 +24,17 @@ class AppConfig(BaseModel):
     aider_code_model: str
     aider_summary_model: str
     gemini_weak_model_name: str
+
+    @property
+    def workspace_root_path(self) -> str:
+        # Assuming this config.py file is at src/config.py
+        # then __file__ is .../src/config.py
+        # os.path.abspath(__file__) gives the absolute path to this file
+        # os.path.dirname(...) once gives .../src/
+        # os.path.dirname(...) twice gives .../ (the workspace root)
+        # Wait, the file is at army-man-small-tweak/src/config.py
+        # So, os.path.dirname() three times is needed.
+        return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
     @classmethod
     def load_from_yaml(cls, config_path: str = "config.yml") -> "AppConfig":


### PR DESCRIPTION
I removed the hardcoded `workspace_root_path` from `army-man-small-tweak/config.yml`.

I modified `army-man-small-tweak/src/config.py` for the `AppConfig` model to dynamically determine the `workspace_root_path` using `os.path.abspath(__file__)`. This makes your configuration more portable and less prone to errors from incorrect hardcoded paths, similar to the approach used in the Secretary project.