### PR TITLE
feat: Allow overriding config values via CLI arguments

### DIFF
--- a/army-man-small-tweak/src/config.py
+++ b/army-man-small-tweak/src/config.py
@@ -26,13 +26,15 @@ class AppConfig(BaseModel):
     gemini_weak_model_name: str
 
     @classmethod
-    def load_from_yaml(cls, config_path: str = "config.yml") -> "AppConfig":
+    def load_from_yaml(cls, config_path: str = "config.yml", root_git_path: Optional[str] = None, goal_path: Optional[str] = None) -> "AppConfig":
         """
         Loads application configuration from a YAML file using OmegaConf
         and instantiates an AppConfig object.
 
         Args:
             config_path: Path to the configuration file.
+            root_git_path: Optional path to the root of the Git repo. If provided, overrides `goal_git_path` from YAML.
+            goal_path: Optional path to the goal root. If provided, overrides `goal_root_path` from YAML.
 
         Returns:
             An instance of AppConfig.
@@ -48,6 +50,16 @@ class AppConfig(BaseModel):
             raw_config = OmegaConf.load(config_path)
 
             config_dict = OmegaConf.to_container(raw_config, resolve=True)
+
+            # Override with provided arguments if they exist
+            if root_git_path is not None:
+                config_dict['goal_git_path'] = root_git_path
+                logger.debug(f"Overriding goal_git_path with provided argument: {root_git_path}")
+
+            if goal_path is not None:
+                config_dict['goal_root_path'] = goal_path
+                logger.debug(f"Overriding goal_root_path with provided argument: {goal_path}")
+
             app_config = cls(**config_dict)
             logger.debug("Application configuration loaded successfully.")
             return app_config

--- a/army-man-small-tweak/src/main.py
+++ b/army-man-small-tweak/src/main.py
@@ -1,4 +1,5 @@
 """Main application entry point for the PoC7 Orchestrator."""
+import argparse
 import logging
 import traceback
 
@@ -29,8 +30,14 @@ def main():
     logger = logging.getLogger(__name__) # Define logger early for initialization errors
 
     try:
+        # Set up argument parsing
+        parser = argparse.ArgumentParser(description="PoC7 LangGraph Orchestrator")
+        parser.add_argument("--root_git_path", type=str, help="Override the goal_git_path from the config YAML.")
+        parser.add_argument("--goal_path", type=str, help="Override the goal_root_path from the config YAML.")
+        args = parser.parse_args()
+
         # Load configuration using the AppConfig class method
-        app_config = AppConfig.load_from_yaml()
+        app_config = AppConfig.load_from_yaml(root_git_path=args.root_git_path, goal_path=args.goal_path)
 
         setup_logging(app_config=app_config)
         # You can now use app_config throughout your application


### PR DESCRIPTION
This change updates army-man-small-tweak to accept command-line arguments for `root_git_path` and `goal_path`.

- I modified `src/config.py` to allow `AppConfig.load_from_yaml` to accept optional `root_git_path` and `goal_path` arguments. If provided, these values override `goal_git_path` and `goal_root_path` from the YAML configuration file.
- I modified `src/main.py` to use `argparse` to parse `--root_git_path` and `--goal_path` command-line arguments. These parsed values are then passed to `AppConfig.load_from_yaml`.

This allows `army-general` to specify these paths when running `army-man-small-tweak`, providing greater flexibility in defining the target and goal locations.